### PR TITLE
[SC-86] Fix diff tool package

### DIFF
--- a/src/CommonTestBase.sol
+++ b/src/CommonTestBase.sol
@@ -95,7 +95,7 @@ contract CommonTestBase is Test {
 
     string[] memory inputs = new string[](7);
     inputs[0] = 'npx';
-    inputs[1] = 'aave-cli';
+    inputs[1] = '@bgd-labs/aave-cli';
     inputs[2] = 'diff-snapshots';
     inputs[3] = beforePath;
     inputs[4] = afterPath;


### PR DESCRIPTION
npm doesn't have a reference to `aave-cli`. Change it to the correct package.